### PR TITLE
fix: 图标D2D位图创建失败时回退到占位图标，修复鼠标悬浮时图标消失

### DIFF
--- a/src/app/app_gfx.h
+++ b/src/app/app_gfx.h
@@ -1309,6 +1309,10 @@ inline void DesktopApp::DrawQuickNavigationOverlay(ID2D1DeviceContext* ctx)
                         static_cast<float>(qnIconRect.right), static_cast<float>(qnIconRect.bottom));
                     ctx->DrawBitmap(bmp, dst, 1.0f, D2D1_INTERPOLATION_MODE_LINEAR);
                 }
+                else
+                {
+                    DrawPlaceholderIcon(ctx, item.sysIconIndex, qnIconRect, 1.0f);
+                }
             }
 
             if (item.shortcutArrow && item.iconState != IconState::Loading)

--- a/src/core/item.cpp
+++ b/src/core/item.cpp
@@ -140,6 +140,10 @@ void DesktopIcon::Draw(ID2D1DeviceContext* context, RECT rect, int state)
                 static_cast<float>(iconRect.right), static_cast<float>(iconRect.bottom));
             context->DrawBitmap(bmp, dst, alpha, D2D1_INTERPOLATION_MODE_LINEAR);
         }
+        else
+        {
+            app_->DrawPlaceholderIcon(context, item_->sysIconIndex, iconRect, alpha);
+        }
     }
 
     if (item_->shortcutArrow && item_->iconState != IconState::Loading)
@@ -272,6 +276,10 @@ void FolderEntryIcon::Draw(ID2D1DeviceContext* context, RECT rect, int state)
                 static_cast<float>(iconRect.left), static_cast<float>(iconRect.top),
                 static_cast<float>(iconRect.right), static_cast<float>(iconRect.bottom));
             context->DrawBitmap(bmp, dst, opacity, D2D1_INTERPOLATION_MODE_LINEAR);
+        }
+        else
+        {
+            app_->DrawPlaceholderIcon(context, entry_->sysIconIndex, iconRect, opacity);
         }
     }
 

--- a/src/widgets/collection.cpp
+++ b/src/widgets/collection.cpp
@@ -175,6 +175,11 @@ void Collection::DrawThumbnail(ID2D1DeviceContext* context,
                 static_cast<float>(iconX + iconSize), static_cast<float>(iconY + iconSize));
             context->DrawBitmap(bmp, dst, 1.0f, D2D1_INTERPOLATION_MODE_LINEAR);
         }
+        else
+        {
+            RECT placeholderRect = { iconX, iconY, iconX + iconSize, iconY + iconSize };
+            app_->DrawPlaceholderIcon(context, item.sysIconIndex, placeholderRect, 1.0f);
+        }
     }
 
     if (item.shortcutArrow && item.iconState != IconState::Loading)


### PR DESCRIPTION
当 iconBitmap 存在但 GetOrCreateD2DBitmap 返回 nullptr 时， 原代码直接跳过绘制导致图标消失。添加 DrawPlaceholderIcon 回退。

Fixes FreeFallingSnow/SnowDesktop_Release#3